### PR TITLE
Verify JWT expiration on each request

### DIFF
--- a/src/main/java/cn/biq/mn/exception/GlobalExceptionHandler.java
+++ b/src/main/java/cn/biq/mn/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.transaction.TransactionSystemException;
 import org.springframework.util.StringUtils;
@@ -125,9 +126,16 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(FailureMessageException.class)
     @ResponseBody
-    public BaseResponse exceptionHandler(FailureMessageException e) {
+    public ResponseEntity<BaseResponse> exceptionHandler(FailureMessageException e) {
         e.printStackTrace();
-        return new SimpleResponse(false, messageSourceUtil.getMessage(e.getMessage()), e.getShowType());
+        if ("user.authentication.empty".equals(e.getMessage())
+                || "user.authentication.invalid".equals(e.getMessage())) {
+            SimpleResponse response = new SimpleResponse(false, HttpStatus.UNAUTHORIZED.value(),
+                    messageSourceUtil.getMessage(e.getMessage()), e.getShowType());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
+        }
+        SimpleResponse response = new SimpleResponse(false, messageSourceUtil.getMessage(e.getMessage()), e.getShowType());
+        return ResponseEntity.ok(response);
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)


### PR DESCRIPTION
## Summary
- validate JWT on every request and clear session when invalid
- reject missing tokens and refresh session data when token changes
- blacklist tokens that fail verification before clearing session
- respond with 401 when authentication fails so the front end can prompt for login

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68903cd66b5c832f8f81266bcd8bf2cb