### PR TITLE
feat: add token refresh with sliding expiration

### DIFF
--- a/src/main/java/cn/biq/mn/security/JwtUtils.java
+++ b/src/main/java/cn/biq/mn/security/JwtUtils.java
@@ -19,10 +19,10 @@ public class JwtUtils {
 
     private final String secretKey = "rzxlszyykpbgqcflzxsqcysyhljt";
 
-    public String createToken(User user) {
+    public String createAccessToken(User user) {
         return JWT.create().withSubject(user.getId().toString())
                 .withClaim("userId", user.getId())
-                .withExpiresAt(Instant.now().plus(Duration.ofDays(30))) //30天之后过期
+                .withExpiresAt(Instant.now().plus(Duration.ofMinutes(15))) //15分钟后过期
                 .sign(Algorithm.HMAC256(secretKey));
     }
 

--- a/src/main/java/cn/biq/mn/security/RefreshToken.java
+++ b/src/main/java/cn/biq/mn/security/RefreshToken.java
@@ -1,0 +1,31 @@
+package cn.biq.mn.security;
+
+import cn.biq.mn.base.BaseEntity;
+import cn.biq.mn.user.User;
+import cn.biq.mn.validation.TimeField;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "t_refresh_token")
+@Getter
+@Setter
+public class RefreshToken extends BaseEntity {
+
+    @Column(length = 512, nullable = false, unique = true)
+    private String token;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private User user;
+
+    @Column(nullable = false)
+    @TimeField
+    private Long expireTime;
+
+    @Column(nullable = false)
+    @TimeField
+    private Long lastUsedTime;
+
+}
+

--- a/src/main/java/cn/biq/mn/security/RefreshTokenRepository.java
+++ b/src/main/java/cn/biq/mn/security/RefreshTokenRepository.java
@@ -1,0 +1,17 @@
+package cn.biq.mn.security;
+
+import cn.biq.mn.base.BaseRepository;
+import cn.biq.mn.user.User;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends BaseRepository<RefreshToken> {
+
+    Optional<RefreshToken> findByToken(String token);
+
+    void deleteByUser(User user);
+
+}
+

--- a/src/main/java/cn/biq/mn/user/UserController.java
+++ b/src/main/java/cn/biq/mn/user/UserController.java
@@ -7,9 +7,10 @@ import cn.biq.mn.utils.MessageSourceUtil;
 import cn.biq.mn.utils.WebUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
 import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.*;
 
 
 @RestController
@@ -26,6 +27,11 @@ public class UserController {
         var result = userService.login(request);
         httpServletRequest.getSession().setAttribute("accessToken", result.getAccessToken());
         return new DataMessageResponse<>(result, messageSourceUtil.getMessage("user.login.success"));
+    }
+
+    @RequestMapping(method = RequestMethod.POST, value = "/refresh")
+    public BaseResponse handleRefresh(@Valid @RequestBody RefreshTokenForm form) {
+        return new DataResponse<>(userService.refreshAccessToken(form.refreshToken()));
     }
 
     @RequestMapping(method = RequestMethod.POST, value = "/logout")
@@ -79,5 +85,7 @@ public class UserController {
     public BaseResponse handleSetDefaultGroup(@PathVariable("id") String id) {
         return new BaseResponse(userService.setDefaultGroupAndBook(id));
     }
+
+    public record RefreshTokenForm(@NotBlank String refreshToken) {}
 
 }


### PR DESCRIPTION
## Summary
- issue short-lived access tokens and store refresh tokens with expiry information
- add endpoint to renew access tokens with sliding expiration
- ensure refresh tokens are saved by using read/write transactions during login and refresh
- inline refresh token form in controller to resolve compilation error

## Testing
- `sh gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689053ee24cc832fb9d84e85cca9c65f