### PR TITLE
Blacklist old access tokens on refresh

### DIFF
--- a/src/main/java/cn/biq/mn/user/UserController.java
+++ b/src/main/java/cn/biq/mn/user/UserController.java
@@ -31,7 +31,13 @@ public class UserController {
 
     @RequestMapping(method = RequestMethod.POST, value = "/refresh")
     public BaseResponse handleRefresh(@Valid @RequestBody RefreshTokenForm form) {
-        return new DataResponse<>(userService.refreshAccessToken(form.refreshToken()));
+        String token = WebUtils.resolveToken(httpServletRequest);
+        if (!StringUtils.hasText(token)) {
+            token = (String) httpServletRequest.getSession().getAttribute("accessToken");
+        }
+        var result = userService.refreshAccessToken(form.refreshToken(), token);
+        httpServletRequest.getSession().setAttribute("accessToken", result.getAccessToken());
+        return new DataResponse<>(result);
     }
 
     @RequestMapping(method = RequestMethod.POST, value = "/logout")


### PR DESCRIPTION
## Summary
- blacklist previous access tokens when issuing a refreshed token
- capture access tokens in refresh endpoint and update session

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6890df39817c832f8fb4c3adae289879